### PR TITLE
fix nav link misalignment, switch to hamburger menu at 2xl breakpoint

### DIFF
--- a/src/components/navbar/DesktopNav.jsx
+++ b/src/components/navbar/DesktopNav.jsx
@@ -42,7 +42,7 @@ export default ({ bgColor, textColor, virufyLogo }) => {
       {({ language: currentLocale }) => (
         <ModalHandler>
           {({ openModal }) => (
-            <div className="md:hidden xs:hidden 2xl:block">
+            <div className="xs:hidden sm:hidden md:hidden 2xl:block">
               <div className="flex justify-between py-3">
                 <Link to="/" className="inline-block w-40 h-12 mx-8">
                   <img

--- a/src/components/navbar/DesktopNav.jsx
+++ b/src/components/navbar/DesktopNav.jsx
@@ -29,10 +29,10 @@ export default ({ bgColor, textColor, virufyLogo }) => {
   const getLinkClasses = (link) => {
     const isActiveLink = isActivePath(location, link);
     return link.btnStyle
-      ? `ml-4 mr-0 pb-2 no-underline text-white py-2 px-6 ${
+      ? `ml-4 mr-0 pb-2 no-underline text-white py-2 px-6 whitespace-nowrap ${
           isActiveLink ? "bg-black" : "bg-blue"
         }`
-      : `ml-4 mr-0 pb-2 no-underline ${textColor} ${
+      : `ml-4 mr-0 pb-2 no-underline whitespace-nowrap ${textColor} ${
           isActiveLink ? "font-bold border-b-4 border-green" : ""
         }`;
   };
@@ -42,9 +42,9 @@ export default ({ bgColor, textColor, virufyLogo }) => {
       {({ language: currentLocale }) => (
         <ModalHandler>
           {({ openModal }) => (
-            <div className="md:hidden xs:hidden lg:block ">
+            <div className="md:hidden xs:hidden 2xl:block">
               <div className="flex justify-between py-3">
-                <Link to="/" className="inline-block w-40 h-12 mx-8 ">
+                <Link to="/" className="inline-block w-40 h-12 mx-8">
                   <img
                     className="logo"
                     src={virufyLogo}
@@ -54,7 +54,7 @@ export default ({ bgColor, textColor, virufyLogo }) => {
                     })}
                   />
                 </Link>
-                <div className="flex items-center text-black font-medium space-x-4 text-sm mr-5">
+                <div className="flex items-center text-black font-medium space-x-2 text-sm mr-5 3xl:space-x-4">
                   {navLinks.map((link, idx) => (
                     <span
                       onMouseEnter={() => setMouseOverLinkIdx(idx)}

--- a/src/components/navbar/LangSelect.jsx
+++ b/src/components/navbar/LangSelect.jsx
@@ -32,7 +32,7 @@ export const LanguageSelectorDropdown = ({ currentLang }) => {
   return (
     <Listbox value={currentLang} onChange={changeLocale}>
       <div className="mt-1 relative">
-        <Listbox.Button className="w-full pl-3 pr-10 py-2">
+        <Listbox.Button className="w-full pl-3 2xl:pr-8 py-2 3xl:pr-10">
           <span className="flex items-center">
             <span className="mr-4 block truncate font-medium">
               {langs[currentLang].name}

--- a/src/components/navbar/MobileNav.jsx
+++ b/src/components/navbar/MobileNav.jsx
@@ -94,7 +94,7 @@ const MobileNav = ({ textColor, bgColor, virufyLogo }) => {
     <ModalHandler>
       {({ openModal }) => (
         <>
-          <div className="pt-6 flex items-start justify-between lg:hidden p-4">
+          <div className="pt-6 flex items-start justify-between 2xl:hidden p-4">
             <MobileNavToggle
               mobileNavOpen={navOpen}
               setMobileNavOpen={setNavOpen}

--- a/src/components/navbar/MobileNav.jsx
+++ b/src/components/navbar/MobileNav.jsx
@@ -105,7 +105,7 @@ const MobileNav = ({ textColor, bgColor, virufyLogo }) => {
                 <img
                   src={virufyLogo}
                   alt="virufy"
-                  className="mr-16 inline-block w-24"
+                  className="mr-16 inline-block w-32"
                 />
               </Link>
             </span>


### PR DESCRIPTION
The Navbar link texts are longest when Japanese is selected, and becomes even longer when the link texts are not wrapped.

With that in mind, as the screen width shrinks below 2xl (1440px), there is not enough space to fit the Virufy logo, Navbar text, and 2 buttons without either having

1. the Virufy logo (on the left) shrink, or
2. the "Join Us" and "Donate" buttons (on the right) shift out of the viewport.

..as shown below:

<img width="1339" alt="Screenshot 2024-02-20 at 6 00 13 PM" src="https://github.com/virufy4/virufy4.github.io/assets/27314227/8257927e-239b-4b3c-99eb-e7c1a56f2918">

<img width="1336" alt="Screenshot 2024-02-20 at 6 04 11 PM" src="https://github.com/virufy4/virufy4.github.io/assets/27314227/032a0716-6ebc-4dee-a248-b482033db6aa">

I tried reducing the spacing between each Navbar link, margin-right on the Virufy logo, and spacing between the buttons but  the issue mentioned above persists. The following changes would prevent that by transitioning the horizontal Navbar menu,

<img width="1432" alt="Screenshot 2024-02-20 at 6 18 44 PM" src="https://github.com/virufy4/virufy4.github.io/assets/27314227/e86cee73-46f2-4863-ab59-1fcfd22a6210">


to the hamburger menu at 2xl (1339px) instead of at lg (1024px).

<img width="1439" alt="Screenshot 2024-02-20 at 6 16 02 PM" src="https://github.com/virufy4/virufy4.github.io/assets/27314227/4db49dbc-9967-48c9-8139-04d963e2f9b7">

If you have other ideas on how to address this, I'm open to suggestions.