### PR TITLE
[W50-231] Remove 'Code of Conduct' link from Website 4.0 Footer

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -60,11 +60,6 @@ const footerLinks = [
     intlId: "footer.dontSellPersonalInfo",
     address: "/ccpa",
   },
-  {
-    intlId: "footer.CodeofConduct",
-    address:
-      "https://github.com/virufy/virufy-covid/blob/main/CODE_OF_CONDUCT.md",
-  },
 ];
 
 export default () => {

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -185,7 +185,7 @@ export default () => {
           <p className="text-sm">
             {intl.formatMessage({
               id: "footer.copyrightInformation",
-              defaultMessage: "©2021 Virufy  | All rights reserved",
+              defaultMessage: "©2024 Virufy | All rights reserved",
             })}
           </p>
         </div>

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -481,7 +481,7 @@
     "cookieSettings": "Cookie Settings",
     "privacyPolicy": "Privacy Policy",
     "dontSellPersonalInfo": "Do Not Sell My Personal Information",
-    "copyrightInformation": "©2022 Virufy  |  VIRUFY is a trademark of The Covid Detection Foundation, a California nonprofit corporation   |  All rights reserved",
+    "copyrightInformation": "©2024 Virufy  |  VIRUFY is a trademark of The Covid Detection Foundation, a California nonprofit corporation   |  All rights reserved",
     "nonprofit": "Virufy is a California nonprofit corporation recognized by the United States Internal Revenue Service (IRS) as a tax-exempt public charity under Section 501(c)(3) of the Internal Revenue Code.",
     "email": "info@virufy.org",
     "address": "",

--- a/src/intl/en/footer.json
+++ b/src/intl/en/footer.json
@@ -3,7 +3,7 @@
   "cookieSettings": "Cookie Settings",
   "privacyPolicy": "Privacy Policy",
   "dontSellPersonalInfo": "Do Not Sell My Personal Information",
-  "copyrightInformation": "©2022 Virufy  |  VIRUFY is a trademark of The Covid Detection Foundation, a California nonprofit corporation   |  All rights reserved",
+  "copyrightInformation": "©2024 Virufy  |  VIRUFY is a trademark of The Covid Detection Foundation, a California nonprofit corporation   |  All rights reserved",
   "nonprofit": "Virufy is a California nonprofit corporation recognized by the United States Internal Revenue Service (IRS) as a tax-exempt public charity under Section 501(c)(3) of the Internal Revenue Code.",
   "email": "info@virufy.org",
   "address": "",

--- a/src/intl/es.json
+++ b/src/intl/es.json
@@ -481,7 +481,7 @@
     "cookieSettings": "Configuración de cookies",
     "privacyPolicy": "Política de privacidad",
     "dontSellPersonalInfo": "No vender mi información personal",
-    "copyrightInformation": "©2022 Virufy | VIRUFY es una marca comercial de The Covid Detection Foundation, una corporación sin fines de lucro de California | Todos los derechos reservados",
+    "copyrightInformation": "©2024 Virufy | VIRUFY es una marca comercial de The Covid Detection Foundation, una corporación sin fines de lucro de California | Todos los derechos reservados",
     "nonprofit": "Virufy es una corporación sin fines de lucro de California reconocida por el Servicio de Rentas Internas de los Estados Unidos (IRS), como una organización benéfica pública exenta de impuestos bajo la Sección 501 (c) (3) del Código de Rentas Internas.",
     "email": "info@virufy.org",
     "address": "",

--- a/src/intl/es/footer.json
+++ b/src/intl/es/footer.json
@@ -3,7 +3,7 @@
   "cookieSettings": "Configuración de cookies",
   "privacyPolicy": "Política de privacidad",
   "dontSellPersonalInfo": "No vender mi información personal",
-  "copyrightInformation": "©2022 Virufy | VIRUFY es una marca comercial de The Covid Detection Foundation, una corporación sin fines de lucro de California | Todos los derechos reservados",
+  "copyrightInformation": "©2024 Virufy | VIRUFY es una marca comercial de The Covid Detection Foundation, una corporación sin fines de lucro de California | Todos los derechos reservados",
   "nonprofit": "Virufy es una corporación sin fines de lucro de California reconocida por el Servicio de Rentas Internas de los Estados Unidos (IRS), como una organización benéfica pública exenta de impuestos bajo la Sección 501 (c) (3) del Código de Rentas Internas.",
   "email": "info@virufy.org",
   "address": "",

--- a/src/intl/ja.json
+++ b/src/intl/ja.json
@@ -481,7 +481,7 @@
     "cookieSettings": "Cookie設定",
     "privacyPolicy": "プライバシーポリシー",
     "dontSellPersonalInfo": "個人情報を販売しない",
-    "copyrightInformation": "©2022 Virufy  |  VIRUFYは、カリフォルニア州の非営利団体The Covid Detection Foundationの商標です。   |  無断転載禁止",
+    "copyrightInformation": "©2024 Virufy  |  VIRUFYは、カリフォルニア州の非営利団体The Covid Detection Foundationの商標です。   |  無断転載禁止",
     "nonprofit": "Virufyは、米国内国歳入庁（IRS）により、内国歳入法第501条（c）（3）に基づく非課税公益法人として認められたカリフォルニア州の非営利法人です。",
     "email": "info@virufy.org",
     "address": "",

--- a/src/intl/ja/footer.json
+++ b/src/intl/ja/footer.json
@@ -3,7 +3,7 @@
   "cookieSettings": "Cookie設定",
   "privacyPolicy": "プライバシーポリシー",
   "dontSellPersonalInfo": "個人情報を販売しない",
-  "copyrightInformation": "©2022 Virufy  |  VIRUFYは、カリフォルニア州の非営利団体The Covid Detection Foundationの商標です。   |  無断転載禁止",
+  "copyrightInformation": "©2024 Virufy  |  VIRUFYは、カリフォルニア州の非営利団体The Covid Detection Foundationの商標です。   |  無断転載禁止",
   "nonprofit": "Virufyは、米国内国歳入庁（IRS）により、内国歳入法第501条（c）（3）に基づく非課税公益法人として認められたカリフォルニア州の非営利法人です。",
   "email": "info@virufy.org",
   "address": "",

--- a/src/intl/pt.json
+++ b/src/intl/pt.json
@@ -481,7 +481,7 @@
     "cookieSettings": "Configurações de cookies",
     "privacyPolicy": "Política de Privacidade",
     "dontSellPersonalInfo": "Não venda minhas informações pessoais",
-    "copyrightInformation": "©2022 Virufy | VIRUFY é uma marca comercial da The Covid Detection Foundation, uma empresa sem fins lucrativos da Califórnia | Todos os direitos reservados",
+    "copyrightInformation": "©2024 Virufy | VIRUFY é uma marca comercial da The Covid Detection Foundation, uma empresa sem fins lucrativos da Califórnia | Todos os direitos reservados",
     "nonprofit": "Virufy é uma corporação sem fins lucrativos da Califórnia reconhecida pelo Internal Revenue Service (IRS) dos Estados Unidos, como uma instituição de caridade pública isenta de impostos de acordo com a Seção 501 (c) (3) do Código da Receita Federal.",
     "email": "info@virufy.org",
     "address": "",

--- a/src/intl/pt/footer.json
+++ b/src/intl/pt/footer.json
@@ -3,7 +3,7 @@
   "cookieSettings": "Configurações de cookies",
   "privacyPolicy": "Política de Privacidade",
   "dontSellPersonalInfo": "Não venda minhas informações pessoais",
-  "copyrightInformation": "©2022 Virufy | VIRUFY é uma marca comercial da The Covid Detection Foundation, uma empresa sem fins lucrativos da Califórnia | Todos os direitos reservados",
+  "copyrightInformation": "©2024 Virufy | VIRUFY é uma marca comercial da The Covid Detection Foundation, uma empresa sem fins lucrativos da Califórnia | Todos os direitos reservados",
   "nonprofit": "Virufy é uma corporação sem fins lucrativos da Califórnia reconhecida pelo Internal Revenue Service (IRS) dos Estados Unidos, como uma instituição de caridade pública isenta de impostos de acordo com a Seção 501 (c) (3) do Código da Receita Federal.",
   "email": "info@virufy.org",
   "address": "",


### PR DESCRIPTION
Removed Code of Conduct link from Footer. Refer to the attached screenshot:

<img width="1440" alt="Screenshot 2024-04-19 at 5 38 17 PM" src="https://github.com/virufy4/virufy4.github.io/assets/121154004/d12d3f41-8fe1-4ccc-b4c8-8758fcbbb750">
